### PR TITLE
t1ger_deliveries | Fix sync bug

### DIFF
--- a/t1ger_deliveries/server/main.lua
+++ b/t1ger_deliveries/server/main.lua
@@ -110,7 +110,7 @@ AddEventHandler('t1ger_deliveries:updateCompany', function(num, val, state, name
         -- add/remove service to/from table:
         if state then 
 			deliveryCompanies[num] = { identifier = xPlayer.identifier, id = num, name = name, level = 0, certificate = false }
-			Config.Companies[num].data = data
+			Config.Companies[num].data = { identifier = xPlayer.identifier, id = num, name = name, level = 0, certificate = false }
         else
 			for i = 1, #deliveryCompanies do
 				if deliveryCompanies[i].id == num then


### PR DESCRIPTION
There is an error in the code using a non-existent variable. Because of this, a business synchronization error occurs, causing it to not work correctly. After purchasing a business, you need to restart the plugin for it to work correctly; the error is accompanied by a message in the console.

The fix is ​​to use an information object about a new object instead of an uninitialized variable.